### PR TITLE
[FEATURE] 선택된 파일의 상태에 따른 버튼 활성화 구현

### DIFF
--- a/files_new.py
+++ b/files_new.py
@@ -16,7 +16,6 @@ from pathlib import Path
 from ftplib import FTP
 from send2trash import send2trash
 
-
 # git status dictionary
 git_status_dict = {
     -1: "NOT_GIT_REPOSITORY",
@@ -42,7 +41,7 @@ git_status_dict = {
 
 
 def git_restore():
-    if check_git_repo() == True:
+    if check_git_repo(last_path):
         repo = pygit2.Repository(last_path)
         head_commit = repo.head.peel(pygit2.Commit)
         head_tree = head_commit.tree
@@ -57,7 +56,7 @@ def git_restore():
 
 
 def git_restore_staged():
-    if check_git_repo() == True:
+    if check_git_repo(last_path):
         repo = pygit2.Repository(last_path)
         index = repo.index
         index.read()
@@ -70,7 +69,7 @@ def git_restore_staged():
 
 
 def git_rm_cached():
-    if check_git_repo() == True:
+    if check_git_repo(last_path):
         try:
             repo = pygit2.Repository(last_path)
             repo.index.remove(g_current_item)
@@ -81,7 +80,7 @@ def git_rm_cached():
 
 
 def git_rm():
-    if check_git_repo() == True:
+    if check_git_repo(last_path):
         try:
             repo = pygit2.Repository(last_path)
             tmp_path = last_path + "/" + g_current_item
@@ -95,12 +94,12 @@ def git_rm():
 
 def git_init():
     # non-bare repository init
-    if check_git_repo() == False:
+    if not check_git_repo(last_path):
         pygit2.init_repository('/.git', False)
 
 
 def git_add():
-    if check_git_repo() == True:
+    if check_git_repo(last_path):
         repository = pygit2.Repository(last_path)
     index = repository.index
     index.add_all()
@@ -109,7 +108,7 @@ def git_add():
 
 
 def git_commit(commit_message):
-    if check_git_repo() == True:
+    if check_git_repo(last_path):
         repository = pygit2.Repository(last_path)
     index = repository.index
     config = repository.config
@@ -132,7 +131,7 @@ def git_commit(commit_message):
 
 
 def git_mv(new_file_name):
-    if check_git_repo() == True:
+    if check_git_repo(last_path):
         repository = pygit2.Repository(last_path)
         index = repository.index
         old_file_name = g_current_item
@@ -147,12 +146,10 @@ def git_mv(new_file_name):
 
 def current_file_git_status():
     status = None
-    if (check_git_repo() == True):
+    if check_git_repo(last_path):
         repository = pygit2.Repository(last_path)
-        try:
-            status = repository.status_file(g_current_item)
-        except KeyError:
-            status = None
+    else:
+        status =0
     return status
 
 
@@ -167,22 +164,14 @@ def update_file_git_status(path, file_name):
 
 
 # 선택된 파일의
-def check_git_repo():
-    is_git = True
-    # 디렉토리가 Git 저장소인지 확인
-    if os.path.isdir(os.path.join(last_path, ".git")):
-        # Git 저장소로부터 Repository 객체를 생성
-        try:
-            repo = pygit2.Repository(last_path)
-
-        except pygit2.GitError:
-            print("This directory is not a valid Git repository.")
-            is_git = True
-    else:
-        print("This directory is not a Git repository.")
-        is_git = False
-    return is_git
-
+def check_git_repo(path):
+    try:
+        # 디렉토리가 Git 저장소인지 확인 레포가 만들어지면 init 불가능
+        repo = pygit2.Repository(path)
+    except pygit2.GitError:
+        print("This directory is not a valid Git repository.")
+        return False
+    return True
 
 def update_git_repo(path):
     try:

--- a/files_new.py
+++ b/files_new.py
@@ -149,13 +149,14 @@ def git_mv(new_file_name):
         update_files(last_path)
 
 def current_file_git_status():
+    status = None
     if (check_git_repo(last_path)):
         repository = pygit2.Repository(last_path)
-        status = repository.status_file(g_current_item)
-    else:
-        status = 0
+        try:
+            status = repository.status_file(g_current_item)
+        except KeyError:
+            status = None
     return status
-
 
 
 def update_file_git_status(path, file_name):

--- a/files_new.py
+++ b/files_new.py
@@ -37,14 +37,7 @@ git_status_dict = {
     16384: "GIT_STATUS_IGNORED",
     32768: "GIT_STATUS_CONFLICTED"
 }
-<<<<<<< HEAD
-=======
-
-
->>>>>>> develop
 # Interface
-
-
 def git_restore():
     if check_git_repo(last_path):
         repo = pygit2.Repository(last_path)
@@ -100,11 +93,7 @@ def git_rm():
 def git_init():
     # non-bare repository init
     if not check_git_repo(last_path):
-<<<<<<< HEAD
-        pygit2.init_repository('/.git', False)
-=======
         pygit2.init_repository(f'{last_path}/.git', False)
->>>>>>> develop
 
 
 def git_add():
@@ -158,19 +147,11 @@ def git_mv(new_file_name):
         update_files(last_path)
 
 def current_file_git_status():
-<<<<<<< HEAD
-    status = None
-    if check_git_repo(last_path):
-        repository = pygit2.Repository(last_path)
-    else:
-        status =0
-=======
-    if check_git_repo(last_path):
+    if (check_git_repo(last_path)):
         repository = pygit2.Repository(last_path)
         status = repository.status_file(g_current_item)
     else:
         status = 0
->>>>>>> develop
     return status
 
 
@@ -189,20 +170,10 @@ def check_git_repo(path):
     try:
         # 디렉토리가 Git 저장소인지 확인 레포가 만들어지면 init 불가능
         repo = pygit2.Repository(path)
-<<<<<<< HEAD
     except pygit2.GitError:
         print("This directory is not a valid Git repository.")
         return False
     return True
-=======
-
-    except pygit2.GitError:
-        print("This directory is not a valid Git repository.")
-        return False
-
-    return True
-
->>>>>>> develop
 
 def update_git_repo(path):
     try:
@@ -310,9 +281,11 @@ def select():
         select_row = tree.focus()
         row_data = tree.item(select_row)
         g_current_item = row_data["text"]
-<<<<<<< HEAD
+
+        if not tree.selection():
+            g_current_item = ''
         current_git_status = current_file_git_status()
-        if check_git_repo() ==True:
+        if check_git_repo(last_path):
             try : 
                 if git_status_dict[current_git_status] == "STAGED":
                     for x in buttons:
@@ -352,10 +325,7 @@ def select():
                     continue
                 else:
                     x.config(state = "disabled")
-=======
-        if not tree.selection():
-            g_current_item = ''
->>>>>>> develop
+
     except IndexError:
         print("IndexError occurred No file selected")
         g_current_item = None

--- a/files_new.py
+++ b/files_new.py
@@ -16,6 +16,28 @@ from pathlib import Path
 from ftplib import FTP
 from send2trash import send2trash
 
+
+# git status dictionary
+git_status_dict = {
+    -1: "NOT_GIT_REPOSITORY",
+    0: "UNMODIFIED",
+    1: "STAGED",
+    2: "STAGED",
+    4: "GIT_STATUS_INDEX_DELETED",
+    8: "GIT_STATUS_INDEX_RENAMED",
+    16: "GIT_STATUS_INDEX_TYPECHANGE",
+    128: "UNTRACKED",
+    132: "UNTRACKED",
+    256: "UNSTAGED",
+    257: "UNSTAGED-STAGED",
+    258: "UNSTAGED-STAGED",
+    512: "GIT_STATUS_WT_DELETED",
+    1024: "GIT_STATUS_WT_RENAMED",
+    2048: "GIT_STATUS_WT_TYPECHANGE",
+    4096: "GIT_STATUS_WT_UNREADABLE",
+    16384: "GIT_STATUS_IGNORED",
+    32768: "GIT_STATUS_CONFLICTED"
+}
 # Interface
 
 
@@ -267,11 +289,25 @@ def select():
         select_row = tree.focus()
         row_data = tree.item(select_row)
         g_current_item = row_data["text"]
-        print(current_file_git_status())
+        current_git_status = current_file_git_status()
+        try : 
+            if git_status_dict[current_git_status] == "STAGED":
+                print(1)
+            elif git_status_dict[current_git_status] == "UNMODIFIED":
+                print(git_status_dict[current_git_status])
+            elif git_status_dict[current_git_status] == "UNSTAGED":
+                print("Unstaged")
+            elif git_status_dict[current_git_status] == "UNTRACKED":
+                print("UNTRACKED")
+            elif git_status_dict[current_git_status] == "UNSTAGED-STAGED":
+                print("UNSTAGED-STAGED")
+            else:
+                print(None)
+        except :
+            print("Invalid Git status code:", current_git_status)
         #print(row_data)
         #current_git_state = row_data["values"][4]
-        #print(current_git_state)
-        
+        #print(current_git_state)  
     except IndexError:
         print("IndexError occurred No file selected")
         g_current_item = None
@@ -862,22 +898,38 @@ frame_down = tk.Frame(window, border=1)
 frame_down.pack(fill="x", side="bottom")
 frame_c = tk.Frame(frame_down, relief="groove", bg="white")
 frame_c.pack(side="bottom")
-tk.Button(frame_c, text='init', width=5, height=1, relief="flat", bg="black",
-          fg="black", command=lambda: git_init()).grid(column=1, row=0)
-tk.Button(frame_c, text='add', width=5, height=1, relief="flat", bg="black",
-          fg="black", command=lambda: git_add()).grid(column=2, row=0)
-tk.Button(frame_c, text='commit', width=5, height=1, relief="flat", bg="black",
-          fg="black", command=lambda: confirm_staged_files()).grid(column=3, row=0)
-tk.Button(frame_c, text='rm', width=5, height=1, relief="flat", bg="black",
-          fg="black", command=lambda: git_rm()).grid(column=4, row=0)
-tk.Button(frame_c, text='rm --cached', width=8, height=1, relief="flat", bg="black",
-          fg="black", command=lambda: git_rm_cached()).grid(column=5, row=0)
-tk.Button(frame_c, text='restore', width=6, height=1, relief="flat", bg="black",
-          fg="black", command=lambda: git_restore()).grid(column=6, row=0)
-tk.Button(frame_c, text='restore --staged', width=10, height=1, relief="flat", bg="black",
-          fg="black", command=lambda: git_restore_staged()).grid(column=7, row=0)
-tk.Button(frame_c, text='mv', width=6, height=1, relief="flat", bg="black",
-          fg="black", command=lambda: open_git_mv_window()).grid(column=8, row=0)
+#init button
+init_button = tk.Button(frame_c, text='init', width=5, height=1, relief="flat", bg="black",
+          fg="black", command=lambda: git_init())
+init_button.grid(column=1, row=0)
+#add button
+add_button = tk.Button(frame_c, text='add', width=5, height=1, relief="flat", bg="black",
+          fg="black", command=lambda: git_add())
+add_button.grid(column=2, row=0)
+#commit button
+commit_button = tk.Button(frame_c, text='commit', width=5, height=1, relief="flat", bg="black",
+          fg="black", command=lambda: confirm_staged_files())
+commit_button.grid(column=3, row=0)
+#git_rm button
+rm_button = tk.Button(frame_c, text='rm', width=5, height=1, relief="flat", bg="black",
+          fg="black", command=lambda: git_rm())
+rm_button.grid(column=4, row=0)
+#git_rm_cached button
+rm_cached_button = tk.Button(frame_c, text='rm --cached', width=8, height=1, relief="flat", bg="black",
+          fg="black", command=lambda: git_rm_cached())
+rm_cached_button.grid(column=5, row=0)
+#git_restore button
+restore_button = tk.Button(frame_c, text='restore', width=6, height=1, relief="flat", bg="black",
+          fg="black", command=lambda: git_restore())
+restore_button.grid(column=6, row=0)
+#git_restore --staged button
+restore_staged_button = tk.Button(frame_c, text='restore --staged', width=10, height=1, relief="flat", bg="black",
+          fg="black", command=lambda: git_restore_staged())
+restore_staged_button.grid(column=7, row=0)
+#git_mv button
+mv_button = tk.Button(frame_c, text='mv', width=6, height=1, relief="flat", bg="black",
+          fg="black", command=lambda: open_git_mv_window())
+mv_button.grid(column=8, row=0)
 
 entry = tk.Entry(frame_up, font=("Arial", 12), justify="left",
                  highlightcolor="white", highlightthickness=0, relief="groove", border=2)

--- a/files_new.py
+++ b/files_new.py
@@ -64,8 +64,7 @@ def git_restore_staged():
         index.remove(g_current_item)
         obj = repo.revparse_single(
             'HEAD').tree[g_current_item]  # Get object from db
-        index.add(pygit2.IndexEntry(g_current_item,
-                  obj.id, obj.filemode))  # Add to inde
+        index.add(pygit2.IndexEntry(g_current_item, obj.id, obj.filemode))  # Add to inde
         index.write()
     update_files(last_path)
 
@@ -285,29 +284,53 @@ def up_down_focus():
 
 def select():
     global g_current_item
+    for x in buttons:
+        x.config(state="normal")
     try:
         select_row = tree.focus()
         row_data = tree.item(select_row)
         g_current_item = row_data["text"]
         current_git_status = current_file_git_status()
-        try : 
-            if git_status_dict[current_git_status] == "STAGED":
-                print(1)
-            elif git_status_dict[current_git_status] == "UNMODIFIED":
-                print(git_status_dict[current_git_status])
-            elif git_status_dict[current_git_status] == "UNSTAGED":
-                print("Unstaged")
-            elif git_status_dict[current_git_status] == "UNTRACKED":
-                print("UNTRACKED")
-            elif git_status_dict[current_git_status] == "UNSTAGED-STAGED":
-                print("UNSTAGED-STAGED")
-            else:
-                print(None)
-        except :
-            print("Invalid Git status code:", current_git_status)
-        #print(row_data)
-        #current_git_state = row_data["values"][4]
-        #print(current_git_state)  
+        if check_git_repo() ==True:
+            try : 
+                if git_status_dict[current_git_status] == "STAGED":
+                    for x in buttons:
+                        if x == commit_button or x==restore_staged_button or x== rm_cached_button :
+                            continue
+                        else:
+                            x.config(state = "disabled")
+
+                elif git_status_dict[current_git_status] == "UNMODIFIED":
+                    for x in buttons:
+                        if x == rm_button or x == rm_cached_button or x == mv_button:
+                            continue
+                        else:
+                            x.config(state= "disabled")
+                elif git_status_dict[current_git_status] == "UNSTAGED":
+                    for x in buttons :
+                        if x == add_button or x == rm_button or x == rm_cached_button or x == mv_button or x==restore_button :
+                            continue
+                        else:
+                            x.config(state = "disabled")
+
+                elif git_status_dict[current_git_status] == "UNTRACKED":
+                    for x in buttons:
+                        if x==add_button:
+                            continue
+                        else:
+                            x.config(state = "disabled")
+                elif git_status_dict[current_git_status] == "UNSTAGED-STAGED":
+                    init_button.config(state= "disabled")
+                else:
+                    print(None)
+            except :
+                print("Invalid Git status code:", current_git_status)
+        else:
+            for x in buttons:
+                if x == init_button:
+                    continue
+                else:
+                    x.config(state = "disabled")
     except IndexError:
         print("IndexError occurred No file selected")
         g_current_item = None
@@ -898,38 +921,47 @@ frame_down = tk.Frame(window, border=1)
 frame_down.pack(fill="x", side="bottom")
 frame_c = tk.Frame(frame_down, relief="groove", bg="white")
 frame_c.pack(side="bottom")
+buttons = []
 #init button
 init_button = tk.Button(frame_c, text='init', width=5, height=1, relief="flat", bg="black",
           fg="black", command=lambda: git_init())
 init_button.grid(column=1, row=0)
+buttons.append(init_button)
 #add button
 add_button = tk.Button(frame_c, text='add', width=5, height=1, relief="flat", bg="black",
           fg="black", command=lambda: git_add())
 add_button.grid(column=2, row=0)
+buttons.append(add_button)
 #commit button
 commit_button = tk.Button(frame_c, text='commit', width=5, height=1, relief="flat", bg="black",
           fg="black", command=lambda: confirm_staged_files())
 commit_button.grid(column=3, row=0)
+buttons.append(commit_button)
 #git_rm button
 rm_button = tk.Button(frame_c, text='rm', width=5, height=1, relief="flat", bg="black",
           fg="black", command=lambda: git_rm())
 rm_button.grid(column=4, row=0)
+buttons.append(rm_button)
 #git_rm_cached button
 rm_cached_button = tk.Button(frame_c, text='rm --cached', width=8, height=1, relief="flat", bg="black",
           fg="black", command=lambda: git_rm_cached())
 rm_cached_button.grid(column=5, row=0)
+buttons.append(rm_cached_button)
 #git_restore button
 restore_button = tk.Button(frame_c, text='restore', width=6, height=1, relief="flat", bg="black",
           fg="black", command=lambda: git_restore())
 restore_button.grid(column=6, row=0)
+buttons.append(restore_button)
 #git_restore --staged button
 restore_staged_button = tk.Button(frame_c, text='restore --staged', width=10, height=1, relief="flat", bg="black",
           fg="black", command=lambda: git_restore_staged())
 restore_staged_button.grid(column=7, row=0)
+buttons.append(restore_staged_button)
 #git_mv button
 mv_button = tk.Button(frame_c, text='mv', width=6, height=1, relief="flat", bg="black",
           fg="black", command=lambda: open_git_mv_window())
 mv_button.grid(column=8, row=0)
+buttons.append(mv_button)
 
 entry = tk.Entry(frame_up, font=("Arial", 12), justify="left",
                  highlightcolor="white", highlightthickness=0, relief="groove", border=2)

--- a/files_new.py
+++ b/files_new.py
@@ -298,6 +298,8 @@ def select():
 
         if not tree.selection():
             g_current_item = ''
+            for x in buttons:
+                x.config(state="disabled")
         current_git_status = current_file_git_status()
         if check_git_repo(last_path):
             try : 

--- a/files_new.py
+++ b/files_new.py
@@ -124,12 +124,16 @@ def git_mv(new_file_name):
 
         update_files(last_path)
 
-
 def current_file_git_status():
+    status = None
     if (check_git_repo() == True):
         repository = pygit2.Repository(last_path)
-        status = repository.status_file(g_current_item)
+        try:
+            status = repository.status_file(g_current_item)
+        except KeyError:
+            status = None
     return status
+
 
 
 def update_file_git_status(path, file_name):
@@ -263,6 +267,11 @@ def select():
         select_row = tree.focus()
         row_data = tree.item(select_row)
         g_current_item = row_data["text"]
+        print(current_file_git_status())
+        #print(row_data)
+        #current_git_state = row_data["values"][4]
+        #print(current_git_state)
+        
     except IndexError:
         print("IndexError occurred No file selected")
         g_current_item = None


### PR DESCRIPTION
1. 현재 파일에 상태에 따라 버튼을 업데이트해주도록 select함수를 변경했습니다.
- ?? : UNTRACKED(128, 132) -> add만 가능
- A : STAGED(1, 2) -> commit , git restore —staged, git rm —cached 만 가능
- _M : UNSTAGED (256) -> git rm, git rm —cached , git mv , git restore (git restore —staged력해도 안돌아감) 만 가능
- MM : UNSTAGED, STAGED (257, 258) git add , git restore —staged , git commit , git rm , git rm —cached, git mv, git
restore 가능
- nothing : UNMODIFIED (0) -> git rm, git rm —cached , git mv 만 가능 , (git restore —staged,git restore 입력해도 안돌아감)
이렇게 분류하였습니다..!
2. Merge conflict를 해소하였습니다. 중간에 PR이 한 번 더 들어오고, merge가 잘못된 줄도 해결하였습니다.
3. 위의 파일 상태 뿐 아니라, git init을 해야하는 상황(not git repo) + button이 눌리고 선택된 것이 없을 때의 상황도 해결하였습니다.